### PR TITLE
Create a configuration option to turn off tracking

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -109,6 +109,10 @@ class Module implements
                         $tracker->setAllowLinker($config['allow_linker']);
                     }
 
+                    if (false === $config['enable']) {
+                        $tracker->setEnableTracking(false);
+                    }
+
                     return $tracker;
                 },
             ),

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -41,6 +41,7 @@
 
 return array(
     'google_analytics' => array(
+        'enable'       => true,
         'id'           => '',
         'domain_name'  => '',
         'allow_linker' => false,

--- a/config/slmgoogleanalytics.global.php.dist
+++ b/config/slmgoogleanalytics.global.php.dist
@@ -17,6 +17,15 @@ $googleAnalytics = array(
      */
     'domain_name' 	=> '',
     'allow_linker' => false,
+
+    /**
+     * Disable/enable page tracking
+     *
+     * It is adviced to turn off tracking in a development/staging environment. Put this
+     * configuration option in your local.php in the autoload folder and set "enable" to
+     * false.
+     */
+    // 'enable' => false,
 );
 
 /**

--- a/src/SlmGoogleAnalytics/Analytics/Tracker.php
+++ b/src/SlmGoogleAnalytics/Analytics/Tracker.php
@@ -105,7 +105,7 @@ class Tracker
     {
         $this->enablePageTracking = (bool) $enable_page_tracking;
     }
-    
+
     public function setAllowLinker($allow_linker)
     {
         $this->allowLinker = (bool) $allow_linker;
@@ -120,7 +120,7 @@ class Tracker
     {
         if (!is_string($domain_name))
             throw new InvalidArgumentException('$domain_name is not a string');
-            
+
         $this->domainName = $domain_name;
     }
 
@@ -143,7 +143,7 @@ class Tracker
     {
         $this->anonymizeIp = (bool) $flag;
     }
-    
+
     public function events ()
     {
         return $this->events;


### PR DESCRIPTION
In development/staging environments you can now turn off tracking
by a configuration variable in your local.php autoload config file.
