### PR TITLE
CustomVariable overwrite key name

### DIFF
--- a/src/SlmGoogleAnalytics/Analytics/CustomVariable.php
+++ b/src/SlmGoogleAnalytics/Analytics/CustomVariable.php
@@ -48,13 +48,15 @@ class CustomVariable
     protected $name;
     protected $value;
     protected $scope;
+    protected $override = false;
 
-    public function __construct($index, $name, $value, $scope = self::SCOPE_PAGE_LEVEL)
+    public function __construct($index, $name, $value, $scope = self::SCOPE_PAGE_LEVEL, $override = false)
     {
         $this->setIndex($index);
         $this->setName($name);
         $this->setValue($value);
         $this->setScope($scope);
+        $this->setOverride($override);
     }
 
     public function setIndex($index)
@@ -115,5 +117,15 @@ class CustomVariable
     public function getScope()
     {
         return $this->scope;
+    }
+
+    public function setOverride($override)
+    {
+        $this->override = $override;
+    }
+
+    public function getOverride()
+    {
+        return $this->override;
     }
 }

--- a/src/SlmGoogleAnalytics/View/Helper/Script/Analyticsjs.php
+++ b/src/SlmGoogleAnalytics/View/Helper/Script/Analyticsjs.php
@@ -174,11 +174,15 @@ SCRIPT;
 
         if (count($customVariables) > 0) {
             foreach ($customVariables as $customVariable) {
-                $index = $customVariable->getIndex();
-                $key   = 'dimension' . $index;
-                $value = $customVariable->getValue();
+                if ($customVariable->getOverride()) {
+                    $parameters[$customVariable->getName()] = $customVariable->getValue();
+                } else {
+                    $index = $customVariable->getIndex();
+                    $key   = 'dimension' . $index;
+                    $value = $customVariable->getValue();
 
-                $parameters[$key] = $value;
+                    $parameters[$key] = $value;
+                }
             }
         }
 


### PR DESCRIPTION
Allows CustomVariable key to be overwritten, this allows the user to add custom variables without the dimension as the key
